### PR TITLE
Fixed extracting settings element from section files Error

### DIFF
--- a/src/lib/Theme.ts
+++ b/src/lib/Theme.ts
@@ -540,9 +540,19 @@ export default class Theme {
         return settings;
     }
     private static extractSettingsFromFile(path) {
-        let $ = cheerio.load(readFile(path));
-        let settingsText = $('settings').text();
-        return settingsText ? JSON.parse(settingsText) : {};
+        try {
+            let $ = cheerio.load(readFile(path));
+            let settingsText = $('settings').text();
+
+            try {
+                return settingsText ? JSON.parse(settingsText) : {};
+            } catch(err) {
+                const themeFilePath = path.split('sections')[1];
+                throw new Error(`Invalid JSON Object in /theme/sections${themeFilePath}. Validate JSON from https://jsonlint.com/`);
+            }
+        } catch(error) {
+            throw new Error(`Extracting settings element from section files failed.!`);
+        }
     }
     private static validateSections(available_sections) {
         let fileNameRegex = /^[0-9a-zA-Z-_ ... ]+$/;


### PR DESCRIPTION
**Problem:** JSON read from section files while theme sync fails when invalid json is parsed. No proper error message was shown.

**Fixes**
- Added `try-catch` block for JSON parse statement.
- Added `try-catch` block for `extractSettingsFromFile` method to throw proper error message for ease of debugging.

JIRA: https://gofynd.atlassian.net/browse/FPCO-3850