### PR TITLE
Fix package update available message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "2.3.6-beta.2",
+  "version": "2.3.5",
   "main": "index.js",
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "2.3.5",
+  "version": "2.3.6-beta.2",
   "main": "index.js",
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "main": "index.js",
   "license": "MIT",
   "bin": {

--- a/src/fdk.ts
+++ b/src/fdk.ts
@@ -171,7 +171,7 @@ export function parseCommands(){
 }
 
 async function checkCliVersionAsync() {
-    return await latestVersion(packageJSON.name, {version: '2.x.x'}); // NOTE: Update the version for the next major version release.
+    return await latestVersion(packageJSON.name, {version: '*'});
 }
 
 async function promptForFDKFolder() {

--- a/src/fdk.ts
+++ b/src/fdk.ts
@@ -171,7 +171,7 @@ export function parseCommands(){
 }
 
 async function checkCliVersionAsync() {
-    return await latestVersion(packageJSON.name);
+    return await latestVersion(packageJSON.name, {version: '2.x.x'}); // NOTE: Update the version for the next major version release.
 }
 
 async function promptForFDKFolder() {


### PR DESCRIPTION
### Fix package update available message on every command

#### Why this change ?
- When a new version of fdk-cli is available, a message is shown to the end users to update the package.
- This behaviour is also working for `beta` releases, Ideally should only work for public stable releases.

#### What has changed ?
- Added `semver` range query in latest-version package check.

#### JIRA: https://gofynd.atlassian.net/browse/FPCO-4119