### PR TITLE
ID: 3985; HOURS: 12; DONE: 100; Fix request handling on server during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "2.3.7",
+  "version": "2.3.8-alpha.6",
   "main": "index.js",
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "2.3.8-alpha.6",
+  "version": "2.3.8-alpha.7",
   "main": "index.js",
   "license": "MIT",
   "bin": {

--- a/src/helper/serve.utils.ts
+++ b/src/helper/serve.utils.ts
@@ -119,6 +119,8 @@ export async function startServer({ domain, host, isSSR, port }) {
 		return res.end()
 	})
 	app.get('/*', async (req, res) => {
+		const BUNDLE_PATH = path.join(process.cwd(), path.join('.fdk', 'dist', 'themeBundle.common.js'));
+		if(!fs.existsSync(BUNDLE_PATH)) return res.send(`<h1>Loading</h1>`);
 
 		if (req.originalUrl == '/favicon.ico' || req.originalUrl == '/.webp') {
 			return res.status(404).send('Not found');
@@ -127,7 +129,6 @@ export async function startServer({ domain, host, isSSR, port }) {
 		const jetfireUrl = new URL(urlJoin(domain, req.originalUrl));
 		let themeUrl = "";
 		if (isSSR) {
-            const BUNDLE_PATH = path.join(process.cwd(), '/.fdk/dist/themeBundle.common.js');
             const User = Configstore.get(CONFIG_KEYS.USER);
             themeUrl = (await UploadService.uploadFile(BUNDLE_PATH, 'fdk-cli-dev-files', User._id))
                 .start.cdn.url;


### PR DESCRIPTION
### Handle server error gracefully when request is received during bundle build.

#### Why this change ?
- When a request is received on the server when it is still in bundle build process, error is thrown on the server as no bundle file is present.

#### What has changed ?
- Check if bundle file is present, if not throw loading message.

**JIRA:** https://gofynd.atlassian.net/browse/FPCO-3985