### PR TITLE
Delete sourcemap for npm publish

### DIFF
--- a/.github/workflows/on_push_tag.yml
+++ b/.github/workflows/on_push_tag.yml
@@ -76,7 +76,7 @@ jobs:
       #     RELEASE_VERSION: ${{ steps.fdk-cli-version.outputs.current-version }}
 
       - name: Delete SourceMap files
-        run: rm -rf ./dist/**/*.map
+        run: find ./dist -type f -name '*.map' -exec rm -f {} \;
 
       - name: Publish to npmjs (beta)
         run: npm publish --tag beta --access public

--- a/.github/workflows/on_release_create.yml
+++ b/.github/workflows/on_release_create.yml
@@ -73,7 +73,7 @@ jobs:
             #     RELEASE_VERSION: ${{ steps.fdk-cli-version.outputs.current-version }}
       
             - name: Delete SourceMap files
-              run: rm -rf ./dist/**/*.map
+              run: find ./dist -type f -name '*.map' -exec rm -f {} \;
             
             - name: Publish to npmjs
               run: npm publish --access public


### PR DESCRIPTION
`rm -rf ./dist/**/*.map` was not deleting all the .map files in nested sub directories in github action pipeline.