### PR TITLE
Remove SENTRY_DSN overwriting script

### DIFF
--- a/src/helper/serve.utils.ts
+++ b/src/helper/serve.utils.ts
@@ -229,14 +229,6 @@ export async function startServer({ domain, host, isSSR, port }) {
 					});
 					</script>
 				`);
-            $('head').append(`
-					<script>
-						if(window.env) {
-							window.env.SENTRY_DSN='';
-							window.env.SENTRY_ENVIRONMENT='development';
-						}
-					</script>
-				`);
 
             const umdJsInitial = $('link[data-umdjs-cli-source="initial"]');
             umdJsInitial.after(


### PR DESCRIPTION
Remove `SENTRY_DSN` overwriting script from fdk theme server command. As all requests are now re-routed to dev server from scattershot.