### PR TITLE
ID:FPP-34565;DONE:100;hours:8,webpack fix for old private themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "8.0.6",
+  "version": "8.0.6-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gofynd/fdk-cli",
-      "version": "8.0.6",
+      "version": "8.0.6-beta.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gofynd/fdk-cli",
-  "version": "8.0.6",
+  "version": "8.0.6-beta.3",
   "main": "index.js",
   "license": "MIT",
   "bin": {
@@ -29,7 +29,7 @@
     "watch": "tsc --watch",
     "test": "node --max_old_space_size=4096 --experimental-vm-modules node_modules/jest/bin/jest --runInBand",
     "pretty": "prettier --config ./.prettierrc --write './src/**/*.*'",
-    "localInstall": "sh scripts/localInstall.sh"
+    "localInstall": "bash scripts/localInstall.sh"
   },
   "devDependencies": {
     "@types/async": "^3.2.24",

--- a/react-template/plugin.js
+++ b/react-template/plugin.js
@@ -1,0 +1,47 @@
+// Shipped by fdk-cli alongside the default webpack.config.js (see header there).
+// Webpack plugin that prepends a snippet (typically polyfill.js content) to every
+// emitted .js asset, so the runtime polyfills are guaranteed to evaluate before
+// any chunk's first line. Required by the default webpack.config.js's `new
+// NodeJSPolyfill({ snippet: <polyfill.js contents> })`. Overwritten if the theme
+// archive ships its own version.
+const { sources } = require("webpack");
+
+class NodeJSPolyfill {
+  // Constructor accepts options, where snippet is optional
+  constructor(options) {
+    this.snippet = options.snippet || ""; // Store the snippet to be prepended to each JavaScript file
+  }
+
+  // Apply method to register the plugin with the webpack compiler
+  apply(compiler) {
+    // Hook into the webpack compilation process
+    compiler.hooks.compilation.tap("NodeJSPolyfill", (compilation) => {
+      // Register a hook for processing assets after they've been added to the compilation
+      compilation.hooks.processAssets.tap(
+        {
+          name: "NodeJSPolyfill", // Name of the plugin for identification
+          stage: compilation.PROCESS_ASSETS_STAGE_ADDITIONS, // Stage to process assets when they've been added
+        },
+        (assets) => {
+          // Iterate over each asset in the compilation
+          for (const assetName in assets) {
+            // Check if the asset is a JavaScript file
+            if (assetName.endsWith(".js")) {
+              // Get the original source of the asset
+              const originalSource = assets[assetName].source();
+
+              // Prepend the snippet to the original source
+              const modifiedSource = `${this.snippet}\n${originalSource}`;
+
+              // Replace the asset's source with the modified source
+              assets[assetName] = new sources.RawSource(modifiedSource);
+            }
+          }
+        }
+      );
+    });
+  }
+}
+
+// Export the plugin class
+module.exports = NodeJSPolyfill;

--- a/react-template/polyfill.js
+++ b/react-template/polyfill.js
@@ -1,0 +1,48 @@
+// Shipped by fdk-cli alongside the default webpack.config.js (see header there).
+// Read at build time and inlined into every emitted .js chunk by the NodeJSPolyfill
+// plugin (./plugin.js). Provides Node-compatible globals (queueMicrotask, Response)
+// for SSR contexts where the theme bundle may evaluate before Node's own globals
+// are present. Overwritten if the theme archive ships its own version.
+
+// Function to check if the code is running in a browser environment
+function isRunningOnClient() {
+  // Checks if 'window' is defined, which indicates a browser environment
+  if (typeof window !== "undefined") {
+    return globalThis === window; // Validates that the global object is 'window'
+  }
+
+  return false; // Returns false if not running in a browser
+}
+
+// Only apply polyfills if running in a server environment
+if (!isRunningOnClient()) {
+  // Polyfill for queueMicrotask if it doesn't exist
+  if (!globalThis.queueMicrotask) {
+    globalThis.queueMicrotask = function queueMicrotaskPolyfil(callback) {
+      // Uses Promise.resolve().then() to simulate queueMicrotask behavior
+      Promise.resolve().then(callback);
+    };
+  }
+
+  // Polyfill for Response object if it doesn't exist
+  if (!globalThis.Response) {
+    globalThis.Response = class Response {
+      constructor() {}
+
+      // Static method to simulate Response.error()
+      static error() {
+        return {};
+      }
+
+      // Static method to simulate Response.json()
+      static json() {
+        return "{}";
+      }
+
+      // Static method to simulate Response.redirect()
+      static redirect() {
+        return {};
+      }
+    };
+  }
+}

--- a/react-template/webpack.config.js
+++ b/react-template/webpack.config.js
@@ -1,0 +1,210 @@
+// Default webpack config shipped by fdk-cli for React themes.
+//
+// Why this file exists in the CLI: the CLI's built-in baseConfig
+// (helper/theme.react.config.ts) only defines output/optimization/externals/plugins
+// — it deliberately does NOT define `entry` or `module.rules`. Those have always
+// been the theme's responsibility, sourced from a root-level `webpack.config.js`.
+//
+// Previously, if a theme archive on the platform was uploaded without one, `fdk
+// theme sync` would crash on the first build attempt with
+// `TypeError: extendedWebpackConfig is not a function`, because the missing
+// config defaulted to `{}` which then got called as a function. By copying this
+// file into the theme directory during `fdk theme init` (before the theme archive
+// is extracted on top), themes always start with a known-good config. If the
+// archive ships its own webpack.config.js / plugin.js / polyfill.js, extract-zip
+// overwrites these defaults — so themes that customize webpack keep their config.
+//
+// Sibling files `plugin.js` and `polyfill.js` are referenced by relative require
+// below and must ship together for the defaults to load.
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const path = require("path");
+const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const NodeJSPolyfill = require("./plugin");
+const { readFileSync } = require("node:fs");
+const { Overlay } = require("react-hydration-overlay");
+
+const polyfillCodePath = path.join(__dirname, "./polyfill.js");
+const polyfillCode = readFileSync(polyfillCodePath, { encoding: "utf-8" });
+
+module.exports = (configOptions) => {
+  const {
+    isLocal,
+    isHMREnabled,
+    context,
+    assetNormalizedBasePath,
+    localBasePath,
+    imageCDNNormalizedBasePath,
+    buildPath,
+    localImageBasePath,
+    localFontsBasePath,
+  } = configOptions;
+  return {
+    entry: {
+      themeBundle: [path.resolve(context, "theme/index.jsx")],
+    },
+    resolve: {
+      extensions: ["", ".js", ".jsx", ".ts", ".tsx"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx)$/,
+          exclude: /node_modules/,
+          use: [
+            {
+              loader: "babel-loader",
+              options: {
+                presets: [
+                  [
+                    "@babel/preset-env",
+                    {
+                      targets: "defaults",
+                    },
+                  ],
+                  "@babel/preset-react",
+                  "@babel/preset-typescript",
+                  "@loadable/babel-plugin",
+                ],
+                plugins: [
+                  ...(isLocal && isHMREnabled
+                    ? [require.resolve("react-refresh/babel")]
+                    : []),
+                ],
+              },
+            },
+          ],
+        },
+        {
+          test: /\.(jsx|js)$/,
+          include: path.resolve(context, "theme"),
+          exclude: /node_modules/,
+          use: [
+            {
+              loader: "babel-loader",
+              options: {
+                presets: [
+                  [
+                    "@babel/preset-env",
+                    {
+                      targets: "defaults",
+                    },
+                  ],
+                  "@babel/preset-react",
+                ],
+                plugins: [
+                  ...(isLocal && isHMREnabled
+                    ? [require.resolve("react-refresh/babel")]
+                    : []),
+                ],
+              },
+            },
+          ],
+        },
+        {
+          test: /\.css$/i,
+          use: [
+            MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: {
+                modules: false,
+              },
+            },
+          ],
+          exclude: /\.global\.css$/,
+        },
+        {
+          test: /\.css$/i,
+          use: [
+            MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: {
+                modules: false,
+              },
+            },
+          ],
+          include: /\.global\.css$/,
+        },
+        {
+          test: /\.less$/i,
+          use: [
+            // compiles Less to CSS
+            MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: {
+                modules: false,
+              },
+            },
+            "less-loader",
+          ],
+          include: /\.global\.less$/,
+        },
+        {
+          test: /\.less$/i,
+          use: [
+            // compiles Less to CSS
+            MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  localIdentName: isLocal
+                    ? "[path][name]__[local]--[hash:base64:5]"
+                    : "[hash:base64:5]",
+                },
+              },
+            },
+            "less-loader",
+          ],
+          exclude: /\.global\.less$/,
+        },
+        {
+          test: /\.(png|jpg|jpeg|gif|webp)$/i,
+          type: "asset/resource",
+          generator: {
+            publicPath: isLocal
+              ? localImageBasePath
+              : imageCDNNormalizedBasePath,
+            outputPath: "assets/images/",
+          },
+        },
+        {
+          test: /\.(ttf|otf|woff|woff2)$/i,
+          type: "asset/resource",
+          generator: {
+            publicPath: isLocal ? localFontsBasePath : assetNormalizedBasePath,
+            outputPath: "assets/fonts/",
+          },
+        },
+        {
+          test: /\.svg$/,
+          use: ["@svgr/webpack"],
+        },
+      ],
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        filename: isLocal ? "[name].css" : "[name].[contenthash].css",
+      }),
+      new NodeJSPolyfill({
+        snippet: polyfillCode,
+      }),
+      ...(isLocal
+        ? [
+            new Overlay({
+              querySelector: "div#app",
+            }),
+          ]
+        : []),
+    ],
+    optimization: {
+      minimizer: [`...`, new CssMinimizerPlugin()],
+    },
+    externals: {
+      "react-i18next": "i18nReact",
+      i18next: "i18next",
+    },
+  };
+};

--- a/src/helper/utils.ts
+++ b/src/helper/utils.ts
@@ -266,10 +266,26 @@ export const isValidDomain = (domain) => {
     return domainRegex.test(domain);
 };
 
+// Only called by `findExportedVariable` below. The goal is *not* to produce a build
+// artifact — it is to strip JSX/TSX syntax so acorn can parse the file and walk for
+// an `export const <name> = ...` declaration. The transformed code is throwaway.
+//
+// `babelrc: false, configFile: false` are load-bearing: without them babel auto-
+// loads the theme's `babel.config.js` (or `.babelrc`). Most React themes include
+// `@babel/preset-env` with the default `modules: 'auto'`, which rewrites every
+// `export const X = ...` into `const X = exports.X = ...`. That collapses the
+// ExportNamedDeclaration node `findExportedVariable` walks for, returning `null`
+// and causing `fdk theme sync` to silently push empty `sections_meta` for every
+// page — wiping out canvas slot declarations (left_panel/right_panel pickers in
+// the editor). The bug is silent because no error is thrown and the sync spinner
+// reports success. See findExportedVariable below for the AST walker that depends
+// on the original `export` syntax being preserved.
 export function transformCodeToJS(code: any) {
     const options = {
         filename: 'pages.tsx',
         presets: ['@babel/preset-react', '@babel/preset-typescript'],
+        babelrc: false,
+        configFile: false,
     };
 
     try {

--- a/src/lib/Theme.ts
+++ b/src/lib/Theme.ts
@@ -659,6 +659,14 @@ export default class Theme {
                 throw new CommandError(`Folder ${themeName}  already exists`);
             }
 
+            // Order matters: template files are copied FIRST, then the theme archive
+            // is extracted on top (extractArchive a few lines below). extract-zip
+            // overwrites by default, so any file the archive ships takes precedence —
+            // but defaults remain for anything the archive omits. The React template
+            // includes a baseline webpack.config.js + plugin.js + polyfill.js so
+            // `fdk theme sync` doesn't crash if the platform-uploaded archive is
+            // missing them (the CLI's baseConfig is incomplete on its own — it has
+            // no `entry` or `module.rules`, both must come from the theme).
             Logger.debug('Copying template config files');
             shouldDelete = true;
             if (themeData.theme_type === THEME_TYPE.react) {


### PR DESCRIPTION
Issue: fdk theme sync silently pushed empty sections_meta for every page, so the editor never knew about canvas slots (Left/Right Panel pickers), and sections saved by the editor had canvas: null — which then failed the page's canvas === "left_panel" filter and rendered nothing.

Why old themes broke but react-starter worked: Old themes (like steve-madden) ship a root babel.config.js with @babel/preset-env (default modules: 'auto'). FDK CLI's transformCodeToJS auto-loaded that config, which rewrote export const sections = ... into const sections = exports.sections = .... The acorn AST walker in findExportedVariable only matches ExportNamedDeclaration nodes, found none, returned null, and sections_meta got pushed as []. React-starter (and newly published themes) don't ship a babel.config.js — babel-loader is configured inline in webpack.config.js — so the CLI's babel transform saw no project config and the export const survived.

Fix and why old themes now work: Added babelrc: false, configFile: false to babel.transformSync in src/helper/utils.ts. The CLI now ignores any project-level babel config when extracting page metadata — preserving the original export const syntax regardless of what the theme's babel.config.js does. Old themes work without any change to their code; just upgrade the CLI and re-sync.